### PR TITLE
Disambiguate "the city" -> "San Francisco"

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
       Here's some info about the rides:
       </p>
       <p>
-      We meet each Thursday at 7AM for coffee & snacks at various coffee houses around the city, then go off and do a ride that gets most people back and into work between 9 and 10. We generally send out the coffee place the Wednesday before the ride, but you can plan on it being at 7AM every Thursday. 
+      We meet each Thursday at 7AM for coffee & snacks at various coffee houses around San Francisco, then go off and do a ride that gets most people back and into work between 9 and 10. We generally send out the coffee place the Wednesday before the ride, but you can plan on it being at 7AM every Thursday. 
       </p>
 
       <p>


### PR DESCRIPTION
``` patch
- We meet each Thursday […] around the city, then go off and do a ride
+ We meet each Thursday […] around San Francisco, then go off and do a ride
```

Better to be clear early on where this happens.

Especially for visitors not from San Francisco who probably don't recognize those locations, it's not really clear, and could lead to disappointment. Easy to nip in the bud.
